### PR TITLE
Detect Streamlit runtime using public API

### DIFF
--- a/airway_builder.py
+++ b/airway_builder.py
@@ -731,8 +731,26 @@ def run_streamlit_app():
             except Exception as e:
                 st.error(f"No se pudo guardar: {e}")
 
+def is_running_with_streamlit() -> bool:
+    """Return True when executed via ``streamlit run``.
+
+    Older versions of this script relied on the private attribute
+    ``st._is_running_with_streamlit``, which has been removed in recent
+    versions of Streamlit.  This helper uses the public runtime API when
+    available and gracefully falls back to ``False`` when the check cannot
+    be performed.
+    """
+
+    try:
+        from streamlit.runtime.scriptrunner import get_script_run_ctx
+
+        return get_script_run_ctx() is not None
+    except Exception:  # pragma: no cover - best effort; imports may fail
+        return False
+
+
 if __name__ == "__main__":
-    if st._is_running_with_streamlit:
+    if is_running_with_streamlit():
         run_streamlit_app()
     else:
         main_cli()


### PR DESCRIPTION
## Summary
- replace deprecated `st._is_running_with_streamlit` check with helper using `streamlit.runtime.scriptrunner.get_script_run_ctx`
- ensure CLI runs when not invoked via `streamlit run`

## Testing
- `python -m py_compile airway_builder.py`
- `python airway_builder.py` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68b638608a9c83258099f2208a952ad7