### PR TITLE
Handle semicolon-delimited waypoint CSV

### DIFF
--- a/airway_builder.py
+++ b/airway_builder.py
@@ -442,7 +442,10 @@ def run_streamlit_app():
     wp_combo_col = None
 
     if selected_wp != "(ninguno)":
-        wp_df = pd.read_csv(os.path.join(data_dir, selected_wp))
+        try:
+            wp_df = pd.read_csv(os.path.join(data_dir, selected_wp))
+        except Exception:
+            wp_df = pd.read_csv(os.path.join(data_dir, selected_wp), sep=";")
     else:
         waypoints_file = st.file_uploader("CSV con waypoints (columnas: nombre opcional, lat/lon o coordenada combinada)", type=["csv"])
         if waypoints_file:


### PR DESCRIPTION
## Summary
- add fallback to parse semicolon-delimited waypoint CSV files

## Testing
- `python -m py_compile airway_builder.py`


------
https://chatgpt.com/codex/tasks/task_e_68b63a149f0c8325861553cdef548e19