### PR TITLE
fix: remove unsupported help argument

### DIFF
--- a/airway_builder.py
+++ b/airway_builder.py
@@ -533,8 +533,8 @@ def run_streamlit_app():
             ),
         },
         key="points_editor",
-        help="Rellena la tabla con los puntos de la aerovía en orden.",
     )
+    st.caption("Rellena la tabla con los puntos de la aerovía en orden.")
     st.session_state.points_df = edited
 
     col_add, col_del, col_kml = st.columns(3)


### PR DESCRIPTION
## Summary
- fix TypeError by removing unsupported `help` parameter from `st.data_editor`
- display guidance using `st.caption`

## Testing
- `python -m py_compile airway_builder.py`


------
https://chatgpt.com/codex/tasks/task_e_68b64c587c248325b046d78cc9f902e0