### PR TITLE
Show all waypoint rows in Streamlit table

### DIFF
--- a/airway_builder.py
+++ b/airway_builder.py
@@ -329,7 +329,7 @@ with st.sidebar:
 st.subheader("1) Cargar CSV de waypoints (automático)")
 wp_path = Path(__file__).resolve().parent / "ENR4_4_CR_2025-05-07.csv"
 wp_df = pd.read_csv(wp_path, sep=";")
-st.dataframe(wp_df.head(20), use_container_width=True)
+st.dataframe(wp_df, use_container_width=True)
 
 wp_name_col = "designador"
 wp_lat_col = "lat"


### PR DESCRIPTION
## Summary
- Display the entire waypoint CSV in the Streamlit interface instead of truncating to the first 20 rows.

## Testing
- `python -m py_compile airway_builder.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6559007d88325ad4c23da48395692