### PR TITLE
Automate route persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ celerybeat.pid
 
 # Python version managers
 .python-version
+
+# App state
+routes_state.json


### PR DESCRIPTION
## Summary
- Auto-load existing route state on startup
- Auto-save route changes without manual buttons
- Ignore generated `routes_state.json`

## Testing
- `python -m py_compile airway_builder.py`


------
https://chatgpt.com/codex/tasks/task_e_68b65d6b634483259eb5b1e941897e80